### PR TITLE
Use generated WAV samples for metronome clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     .sheet h2{margin:0 0 10px 0}
     .sheet p{margin:0 0 14px 0;color:var(--sub)}
     .sheet .btn{width:100%;font-size:18px}
+    .version{margin:40px 0 12px;text-align:center;color:var(--sub);font-size:11px;opacity:.7}
   </style>
 </head>
 <body>
@@ -122,6 +123,8 @@
     </div>
   </div>
 
+  <div class="version">버전 v1.0.2</div>
+
 <script>
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -134,17 +137,204 @@ if ('serviceWorker' in navigator) {
   const unlockOverlay = $('#unlockOverlay');
   const unlockBtn = $('#unlockBtn');
   let audioCtx, unlocked = false;
+  let currentSamples = null;
+  let currentSampleType = null;
+  let soundChoice = 'click';
+  const sampleCache = new Map();
+  const samplePromises = new Map();
 
-  function unlockAudio(){
-    if (unlocked) return;
-    const Ctx = window.AudioContext || window.webkitAudioContext;
-    audioCtx = new Ctx();
-    const buffer = audioCtx.createBuffer(1,1,22050);
-    const src = audioCtx.createBufferSource(); src.buffer = buffer; src.connect(audioCtx.destination); src.start(0);
-    if (audioCtx.state === 'suspended') audioCtx.resume();
-    unlocked = true; unlockOverlay.style.display = 'none';
+  const SOUND_DEFS = {
+    click: {
+      accent: { freq: 2300, duration: 0.14, attack: 0.0018, decay: 0.11, partials: [1, 0.4, 0.18] },
+      normal: { freq: 1800, duration: 0.12, attack: 0.002, decay: 0.1, partials: [1, 0.32, 0.12] },
+      sub: { freq: 1400, duration: 0.1, attack: 0.0024, decay: 0.08, partials: [1, 0.25] }
+    },
+    wood: {
+      accent: { freq: 1050, duration: 0.16, attack: 0.002, decay: 0.13, partials: [1, 0.5, 0.22], noise: 0.08 },
+      normal: { freq: 820, duration: 0.14, attack: 0.0024, decay: 0.11, partials: [1, 0.35, 0.18], noise: 0.05 },
+      sub: { freq: 620, duration: 0.12, attack: 0.003, decay: 0.09, partials: [1, 0.28], noise: 0.04 }
+    },
+    beep: {
+      accent: { freq: 1200, duration: 0.18, attack: 0.003, decay: 0.14, partials: [1] },
+      normal: { freq: 900, duration: 0.16, attack: 0.003, decay: 0.12, partials: [1] },
+      sub: { freq: 720, duration: 0.14, attack: 0.004, decay: 0.1, partials: [1] }
+    }
+  };
+
+  function writeString(view, offset, str){
+    for(let i=0;i<str.length;i++){
+      view.setUint8(offset+i, str.charCodeAt(i));
+    }
   }
-  ['touchstart','mousedown','keydown'].forEach(ev=>window.addEventListener(ev, ()=>{ if(!unlocked) unlockAudio(); }, {once:true, passive:true}));
+
+  function floatTo16BitPCM(view, offset, input){
+    for(let i=0;i<input.length;i++, offset+=2){
+      const s = Math.max(-1, Math.min(1, input[i]));
+      view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+    }
+  }
+
+  function createWavArrayBuffer({ sampleRate, freq, duration, attack, decay, partials, noise }){
+    const length = Math.floor(duration * sampleRate);
+    const data = new Float32Array(length);
+    const attackSamples = Math.max(1, Math.floor(attack * sampleRate));
+    const decayConst = Math.max(0.0001, decay);
+
+    for(let i=0;i<length;i++){
+      const t = i / sampleRate;
+      const envAttack = Math.min(1, i / attackSamples);
+      const envDecay = Math.exp(-t / decayConst);
+      let sample = 0;
+      partials.forEach((amp, idx)=>{
+        sample += amp * Math.sin(2 * Math.PI * freq * (idx + 1) * t);
+      });
+      if(noise){
+        sample += (Math.random() * 2 - 1) * noise;
+      }
+      data[i] = sample * envAttack * envDecay;
+    }
+
+    const bytesPerSample = 2;
+    const dataLength = length * bytesPerSample;
+    const buffer = new ArrayBuffer(44 + dataLength);
+    const view = new DataView(buffer);
+
+    writeString(view, 0, 'RIFF');
+    view.setUint32(4, 36 + dataLength, true);
+    writeString(view, 8, 'WAVE');
+    writeString(view, 12, 'fmt ');
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, 1, true);
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * bytesPerSample, true);
+    view.setUint16(32, bytesPerSample, true);
+    view.setUint16(34, 8 * bytesPerSample, true);
+    writeString(view, 36, 'data');
+    view.setUint32(40, dataLength, true);
+    floatTo16BitPCM(view, 44, data);
+
+    return buffer;
+  }
+
+  function decodeAudioBuffer(ctx, arrayBuffer){
+    return new Promise((resolve, reject)=>{
+      if(ctx.decodeAudioData.length === 1){
+        ctx.decodeAudioData(arrayBuffer).then(resolve).catch(reject);
+      } else {
+        ctx.decodeAudioData(arrayBuffer, resolve, reject);
+      }
+    });
+  }
+
+  async function loadSampleSet(ctx, type){
+    const defs = SOUND_DEFS[type];
+    const entries = await Promise.all(Object.entries(defs).map(async ([key, opts])=>{
+      const arrayBuffer = createWavArrayBuffer({
+        sampleRate: ctx.sampleRate,
+        freq: opts.freq,
+        duration: opts.duration,
+        attack: opts.attack,
+        decay: opts.decay,
+        partials: opts.partials,
+        noise: opts.noise || 0
+      });
+      const decoded = await decodeAudioBuffer(ctx, arrayBuffer);
+      return [key, decoded];
+    }));
+    return Object.fromEntries(entries);
+  }
+
+  async function ensureSamples(ctx, type){
+    if(currentSampleType === type && currentSamples){
+      return currentSamples;
+    }
+    if(sampleCache.has(type)){
+      currentSamples = sampleCache.get(type);
+      currentSampleType = type;
+      return currentSamples;
+    }
+    if(samplePromises.has(type)){
+      const cached = await samplePromises.get(type);
+      currentSamples = cached;
+      currentSampleType = type;
+      return currentSamples;
+    }
+    const promise = loadSampleSet(ctx, type).then(set=>{
+      sampleCache.set(type, set);
+      samplePromises.delete(type);
+      return set;
+    });
+    samplePromises.set(type, promise);
+    const loaded = await promise;
+    currentSamples = loaded;
+    currentSampleType = type;
+    return loaded;
+  }
+
+  function showOverlay(){
+    unlockOverlay.style.display='flex';
+  }
+
+  function hideOverlay(){
+    unlockOverlay.style.display='none';
+  }
+
+  function primeContext(ctx){
+    try {
+      const buffer = ctx.createBuffer(1,1,22050);
+      const src = ctx.createBufferSource();
+      src.buffer = buffer;
+      src.connect(ctx.destination);
+      src.start(0);
+    } catch(e){}
+  }
+
+  function handleStateChange(){
+    if(!audioCtx) return;
+    if(audioCtx.state === 'running'){
+      if(!unlocked){
+        primeContext(audioCtx);
+        unlocked = true;
+        ensureSamples(audioCtx, soundChoice);
+      }
+      hideOverlay();
+    } else {
+      unlocked = false;
+      showOverlay();
+    }
+  }
+
+  async function ensureAudioContext(){
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    if(!Ctx) return null;
+    if(!audioCtx){
+      audioCtx = new Ctx();
+      audioCtx.addEventListener('statechange', handleStateChange);
+    }
+    return audioCtx;
+  }
+
+  async function unlockAudio(){
+    const ctx = await ensureAudioContext();
+    if(!ctx) return null;
+    if(ctx.state !== 'running'){
+      try { await ctx.resume(); } catch(e){}
+    }
+    if(ctx.state !== 'running'){
+      unlocked = false;
+      showOverlay();
+      return null;
+    }
+    if(!unlocked){
+      primeContext(ctx);
+      unlocked = true;
+    }
+    await ensureSamples(ctx, soundChoice);
+    hideOverlay();
+    return ctx;
+  }
+  ['touchstart','mousedown','keydown'].forEach(ev=>window.addEventListener(ev, ()=>{ if(!unlocked) unlockAudio(); }, {passive:true}));
   unlockBtn.addEventListener('click', unlockAudio);
 
   const bpmEl = $('#bpm'); const bpmDisplay = $('#bpmDisplay');
@@ -153,6 +343,7 @@ if ('serviceWorker' in navigator) {
   const beatsEl = $('#beats'); const subdivEl = $('#subdiv');
   const accentFirstEl = $('#accentFirst'); const swingEl = $('#swing');
   const soundEl = $('#sound'); const volumeEl = $('#volume');
+  soundChoice = soundEl.value;
   const visualEl = $('#visual'); const display = $('#display');
   const beatText = $('#beatText'); const leds = $('#leds');
   const minus10 = $('#minus10'); const plus10 = $('#plus10');
@@ -166,19 +357,15 @@ if ('serviceWorker' in navigator) {
   function noteLengthSec(){ const bpm=+bpmEl.value; const base=60/bpm; const subdiv=+subdivEl.value; if(swingEl.checked&&subdiv===2) return base/2; return subdiv>1? base/subdiv: base; }
 
   function scheduleClick(time, isAccent, isSub){
-    if(!audioCtx) return;
-    const vol=+volumeEl.value;
-    const osc=audioCtx.createOscillator();
-    const env=audioCtx.createGain();
-    let freq;
-    const sound=soundEl.value;
-    if(sound==='click'){ freq=isAccent?2000:(isSub?1500:1700);} 
-    else if(sound==='wood'){ freq=isAccent?900:(isSub?650:750);} 
-    else { freq=isAccent?1000:(isSub?700:850);}
-    osc.frequency.value=freq; env.gain.value=0; osc.connect(env).connect(audioCtx.destination);
-    const a=isAccent?0.002:0.003; const d=isAccent?0.06:0.04;
-    env.gain.setValueAtTime(0,time); env.gain.linearRampToValueAtTime(vol,time+a); env.gain.exponentialRampToValueAtTime(0.0001,time+d);
-    osc.start(time); osc.stop(time+d+0.02);
+    if(!audioCtx || audioCtx.state !== 'running' || !currentSamples) return;
+    const buffer = isAccent ? currentSamples.accent : (isSub ? currentSamples.sub : currentSamples.normal);
+    if(!buffer) return;
+    const gainNode = audioCtx.createGain();
+    const src = audioCtx.createBufferSource();
+    src.buffer = buffer;
+    gainNode.gain.setValueAtTime(+volumeEl.value, time);
+    src.connect(gainNode).connect(audioCtx.destination);
+    src.start(time);
   }
 
   function flashVisual(ac){ if(!visualEl.checked) return; display.style.transform='scale(1.02)';
@@ -187,9 +374,13 @@ if ('serviceWorker' in navigator) {
 
   function updateLEDs(active,total){ leds.innerHTML=''; for(let i=0;i<total;i++){ const d=document.createElement('div'); d.className='led'+(i===active?' on':''); leds.appendChild(d);} }
 
-  function scheduler(){ 
-    while(audioCtx && nextNoteTime < audioCtx.currentTime + scheduleAheadTime){ 
-      const beatsPerBar=+beatsEl.value; const subdiv=+subdivEl.value; 
+  function scheduler(){
+    if(!audioCtx || audioCtx.state !== 'running'){
+      stop();
+      return;
+    }
+    while(audioCtx && nextNoteTime < audioCtx.currentTime + scheduleAheadTime){
+      const beatsPerBar=+beatsEl.value; const subdiv=+subdivEl.value;
       const beatIndex=currentBeat % beatsPerBar; 
       const isBarAccent=accentFirstEl.checked && beatIndex===0; 
       let stepsThisBeat=subdiv; if(subdiv===1) stepsThisBeat=1; 
@@ -206,19 +397,32 @@ if ('serviceWorker' in navigator) {
     } 
   }
 
-  function start(){ 
-    if(!unlocked) unlockAudio(); 
-    if(isRunning) return; 
-    isRunning=true; startStopBtn.textContent='정지'; 
-    const beatsPerBar=+beatsEl.value; updateLEDs(0,beatsPerBar); 
-    currentBeat=0; nextNoteTime = audioCtx.currentTime + 0.08; 
-    scheduleTimer = setInterval(scheduler, lookahead); 
+  async function start(){
+    const ctx = await unlockAudio();
+    if(!ctx || ctx.state !== 'running') return;
+    if(isRunning) return;
+    await ensureSamples(ctx, soundChoice);
+    if(!currentSamples) return;
+    isRunning=true; startStopBtn.textContent='정지';
+    const beatsPerBar=+beatsEl.value; updateLEDs(0,beatsPerBar);
+    currentBeat=0; nextNoteTime = ctx.currentTime + 0.08;
+    scheduler();
+    scheduleTimer = setInterval(scheduler, lookahead);
   }
 
-  function stop(){ isRunning=false; startStopBtn.textContent='시작'; if(scheduleTimer) clearInterval(scheduleTimer); }
+  function stop(){
+    isRunning=false; startStopBtn.textContent='시작';
+    if(scheduleTimer){
+      clearInterval(scheduleTimer);
+      scheduleTimer=null;
+    }
+  }
   function reset(){ stop(); tapTimes=[]; beatText.textContent='1'; updateLEDs(0, +beatsEl.value); }
 
-  startStopBtn.addEventListener('click', ()=> isRunning? stop() : start());
+  startStopBtn.addEventListener('click', ()=>{
+    if(isRunning) stop();
+    else start();
+  });
   resetBtn.addEventListener('click', reset);
   bpmEl.addEventListener('input', updateBpmDisplay);
   minus10.addEventListener('click', ()=>{ bpmEl.value=Math.max(20, +bpmEl.value-10); updateBpmDisplay(); });
@@ -234,6 +438,12 @@ if ('serviceWorker' in navigator) {
       bpmEl.value=bpm; updateBpmDisplay(); tapInfo.textContent=`탭 기반 BPM ≈ ${bpm}`; } 
     else { tapInfo.textContent = `${tapTimes.length}회 탭됨…`; } }
   tapBtn.addEventListener('click', onTap);
+  soundEl.addEventListener('change', async ()=>{
+    soundChoice = soundEl.value;
+    if(audioCtx){
+      await ensureSamples(audioCtx, soundChoice);
+    }
+  });
 
   updateBpmDisplay(); updateLEDs(0, +beatsEl.value);
 })();


### PR DESCRIPTION
## Summary
- generate short WAV buffers for each metronome voice and cache them per sound profile
- ensure the audio context loads the new samples when unlocking or switching sounds before scheduling playback
- play metronome beats from the decoded buffers instead of oscillators for better mobile compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f4c9fdc08331a80cd6786e51ac22